### PR TITLE
Fix typo in sar example snippet.

### DIFF
--- a/questions/answers/015.md
+++ b/questions/answers/015.md
@@ -31,7 +31,7 @@ For example:
 
 ```asm
 mov rax, 0xFB00000000000000      
-shr rax, 4                     ; rax = 0xFFB0000000000000
+sar rax, 4                     ; rax = 0xFFB0000000000000
 ```
 
 The `FB` part was shifted to the right. However, the sign bit was equal to 


### PR DESCRIPTION
In the second code snippet of the answer 'shr rax, 4' was written, when
it should be 'sar rax, 4'.